### PR TITLE
Fix not found link to Deployer Hosts documentation

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -113,7 +113,7 @@ Check the [Hosts page][hosts] at the Deployer site for all options.
 
 [dtap]: https://www.phparch.com/2009/07/professional-programming-dtap-%e2%80%93-part-1-what-is-dtap/
 [ssh-keys]: https://linuxize.com/post/how-to-setup-passwordless-ssh-login/
-[hosts]: https://deployer.org/docs/hosts.html
+[hosts]: https://deployer.org/docs/6.x/hosts
 [recipe]: https://github.com/deployphp/deployer/tree/master/recipe
 [tasks]: https://github.com/deployphp/deployer/tree/master/recipe/deploy
 [deployer]: https://deployer.org/docs/hosts.html


### PR DESCRIPTION
The current link to Deployer Hosts documentation page is broken. 

I have changed the link to point to the version of Deployer that is being used in `composer.json ` 
```
"deployer/deployer": "^6.8"
```